### PR TITLE
Add the ability to log request/responses to aid debugging

### DIFF
--- a/account_test.go
+++ b/account_test.go
@@ -40,7 +40,7 @@ func TestAccount_ListPayments(t *testing.T) {
   }
 }`)))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("apiKey", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "apiKey", "secret")
 	require.NoError(t, err)
 
 	actual, err := subject.Account.ListPaymentMethods(context.TODO())

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,212 @@
+package rediscloud_api
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialTripper_DisabledLoggingLogsNothing(t *testing.T) {
+	mockTripper := &mockedRoundTripper{}
+	mockLogger := &mockedLogger{}
+
+	request := &http.Request{
+		Method: http.MethodPost,
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   "example.org",
+		},
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     map[string][]string{},
+		Host:       "example.org",
+	}
+	expected := &http.Response{
+		StatusCode: 200,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+	}
+
+	mockTripper.On("RoundTrip", request).Return(expected, nil)
+
+	subject := &credentialTripper{
+		apiKey:      "KEY THAT SHOULD NOT BE LOGGED",
+		secretKey:   "SECRET KEY THAT SHOULD NOT BE LOGGED",
+		wrapped:     mockTripper,
+		logRequests: false,
+		logger:      mockLogger,
+		userAgent:   "test-user-agent",
+	}
+
+	actual, err := subject.RoundTrip(request)
+	require.NoError(t, err)
+	assert.Same(t, expected, actual)
+	assert.Empty(t, mockLogger.log)
+	assert.Equal(t, "KEY THAT SHOULD NOT BE LOGGED", request.Header.Get("X-Api-Key"))
+	assert.Equal(t, "SECRET KEY THAT SHOULD NOT BE LOGGED", request.Header.Get("X-Api-Secret-Key"))
+}
+
+func TestCredentialTripper_LogsRequestAndResponseBodies(t *testing.T) {
+	mockTripper := &mockedRoundTripper{}
+	mockLogger := &mockedLogger{}
+
+	request := &http.Request{
+		Method: http.MethodPost,
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   "example.org",
+			Path:   "/foo/bar",
+		},
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        map[string][]string{},
+		Body:          ioutil.NopCloser(bytes.NewBufferString(`{"Here":"Value"}`)),
+		ContentLength: 16,
+		Host:          "example.org",
+	}
+	expected := &http.Response{
+		StatusCode: 200,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     map[string][]string{},
+		Body:       ioutil.NopCloser(bytes.NewBufferString(`{"Response":"Value"}`)),
+	}
+
+	mockTripper.On("RoundTrip", request).Return(expected, nil)
+
+	subject := &credentialTripper{
+		apiKey:      "KEY THAT SHOULD NOT BE LOGGED",
+		secretKey:   "SECRET KEY THAT SHOULD NOT BE LOGGED",
+		wrapped:     mockTripper,
+		logRequests: true,
+		logger:      mockLogger,
+		userAgent:   "test-user-agent",
+	}
+
+	actual, err := subject.RoundTrip(request)
+	require.NoError(t, err)
+	assert.Same(t, expected, actual)
+	assert.Equal(t, "KEY THAT SHOULD NOT BE LOGGED", request.Header.Get("X-Api-Key"))
+	assert.Equal(t, "SECRET KEY THAT SHOULD NOT BE LOGGED", request.Header.Get("X-Api-Secret-Key"))
+
+	assert.Equal(t, `DEBUG: Request /foo/bar:
+---[ REQUEST ]---
+POST /foo/bar HTTP/1.1
+Host: example.org
+User-Agent: test-user-agent
+Content-Length: 16
+Accept: application/json
+Accept-Encoding: gzip
+
+{
+  "Here": "Value"
+}`, mockLogger.log[0])
+	assert.Equal(t, `DEBUG: Response /foo/bar:
+---[ RESPONSE ]---
+HTTP/1.1 200 OK
+Connection: close
+
+{
+  "Response": "Value"
+}`, mockLogger.log[1])
+}
+
+func TestCredentialTripper_HandlesNoBodies(t *testing.T) {
+	mockTripper := &mockedRoundTripper{}
+	mockLogger := &mockedLogger{}
+
+	request := &http.Request{
+		Method: http.MethodGet,
+		URL: &url.URL{
+			Scheme: "http",
+			Host:   "example.com",
+			Path:   "/baz",
+		},
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     map[string][]string{},
+		Host:       "example.org",
+	}
+	expected := &http.Response{
+		StatusCode: http.StatusNoContent,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header: map[string][]string{
+			"X-Test": {"Demo"},
+		},
+	}
+
+	mockTripper.On("RoundTrip", request).Return(expected, nil)
+
+	subject := &credentialTripper{
+		apiKey:      "KEY THAT SHOULD NOT BE LOGGED",
+		secretKey:   "SECRET KEY THAT SHOULD NOT BE LOGGED",
+		wrapped:     mockTripper,
+		logRequests: true,
+		logger:      mockLogger,
+		userAgent:   "test-user-agent",
+	}
+
+	actual, err := subject.RoundTrip(request)
+	require.NoError(t, err)
+	assert.Same(t, expected, actual)
+	assert.Equal(t, "KEY THAT SHOULD NOT BE LOGGED", request.Header.Get("X-Api-Key"))
+	assert.Equal(t, "SECRET KEY THAT SHOULD NOT BE LOGGED", request.Header.Get("X-Api-Secret-Key"))
+
+	assert.Equal(t, `DEBUG: Request /baz:
+---[ REQUEST ]---
+GET /baz HTTP/1.1
+Host: example.org
+User-Agent: test-user-agent
+Accept: application/json
+Accept-Encoding: gzip`, mockLogger.log[0])
+	assert.Equal(t, `DEBUG: Response /baz:
+---[ RESPONSE ]---
+HTTP/1.1 204 No Content
+X-Test: Demo`, mockLogger.log[1])
+}
+
+type mockedLogger struct {
+	log []string
+}
+
+func (m *mockedLogger) Printf(format string, v ...interface{}) {
+	m.log = append(m.log, m.trim(fmt.Sprintf(format, v...)))
+}
+
+func (m *mockedLogger) Println(v ...interface{}) {
+	for _, i := range v {
+		m.log = append(m.log, m.trim(fmt.Sprintf("%s", i)))
+	}
+}
+
+func (m mockedLogger) trim(s string) string {
+	return strings.TrimSpace(strings.ReplaceAll(s, "\r", ""))
+}
+
+var _ Log = &mockedLogger{}
+
+type mockedRoundTripper struct {
+	mock.Mock
+}
+
+func (m *mockedRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	args := m.Called(request)
+	return args.Get(0).(*http.Response), args.Error(1)
+}
+
+var _ http.RoundTripper = &mockedRoundTripper{}

--- a/cloud_account_test.go
+++ b/cloud_account_test.go
@@ -51,7 +51,7 @@ func TestCloudAccount_Create(t *testing.T) {
   }
 }`, expected))))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("key", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "key", "secret")
 	require.NoError(t, err)
 
 	actual, err := subject.CloudAccount.Create(context.TODO(), cloud_accounts.CreateCloudAccount{
@@ -103,7 +103,7 @@ func TestCloudAccount_Update(t *testing.T) {
   }
 }`)))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("key", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "key", "secret")
 	require.NoError(t, err)
 
 	err = subject.CloudAccount.Update(context.TODO(), 642, cloud_accounts.UpdateCloudAccount{
@@ -132,7 +132,7 @@ func TestCloudAccount_Get(t *testing.T) {
   }
 }`)))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("apiKey", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "apiKey", "secret")
 	require.NoError(t, err)
 
 	actual, err := subject.CloudAccount.Get(context.TODO(), 98765)
@@ -175,7 +175,7 @@ func TestCloudAccount_Delete(t *testing.T) {
   }
 }`)))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("apiKey", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "apiKey", "secret")
 	require.NoError(t, err)
 
 	err = subject.CloudAccount.Delete(context.TODO(), 98765)

--- a/database_test.go
+++ b/database_test.go
@@ -44,7 +44,7 @@ func TestDatabase_List(t *testing.T) {
   }
 }`)))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("apiKey", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "apiKey", "secret")
 	require.NoError(t, err)
 
 	actual := subject.Database.List(context.TODO(), 23456)
@@ -125,7 +125,7 @@ func TestDatabase_Get(t *testing.T) {
   }
 }`)))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("apiKey", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "apiKey", "secret")
 	require.NoError(t, err)
 
 	actual, err := subject.Database.Get(context.TODO(), 23456, 98765)
@@ -196,7 +196,7 @@ func TestDatabase_Delete(t *testing.T) {
   }
 }`)))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("key", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "key", "secret")
 	require.NoError(t, err)
 
 	err = subject.Database.Delete(context.TODO(), 42, 4291)

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -75,7 +75,7 @@ func TestSubscription_Create(t *testing.T) {
   }
 }`, expected))))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("key", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "key", "secret")
 	require.NoError(t, err)
 
 	actual, err := subject.Subscription.Create(context.TODO(), subscriptions.CreateSubscription{
@@ -144,7 +144,7 @@ func TestSubscription_Delete(t *testing.T) {
   }
 }`)))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("apiKey", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "apiKey", "secret")
 	require.NoError(t, err)
 
 	err = subject.Subscription.Delete(context.TODO(), 12356)

--- a/task_test.go
+++ b/task_test.go
@@ -33,7 +33,7 @@ func TestTask_Get(t *testing.T) {
   }
 }`, resourceId))))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("key", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "key", "secret")
 	require.NoError(t, err)
 
 	actual, err := subject.Task.Get(context.TODO(), "task-uuid")
@@ -72,7 +72,7 @@ func TestTask_Get_UnwrapsTaskError(t *testing.T) {
   }
 }`)))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("key", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "key", "secret")
 	require.NoError(t, err)
 
 	actual, err := subject.Task.Get(context.TODO(), "task-uuid")
@@ -129,7 +129,7 @@ func TestTask_WaitForTaskToComplete(t *testing.T) {
   }
 }`, resourceId, resource))))
 
-	subject, err := NewClient(BaseUrl(s.URL), Auth("key", "secret"), Transporter(s.Client().Transport))
+	subject, err := clientFromTestServer(s, "key", "secret")
 	require.NoError(t, err)
 
 	actual, err := subject.Task.WaitForTaskToComplete(context.TODO(), "task-uuid")


### PR DESCRIPTION
`LogRequest` function will log the requests and responses going to/from the API but will exclude the API access key & secret key to help avoid accidentally leaking secrets.