### PR TITLE
Stop Task API from being accessible outside of this repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 ## 0.1.0 (Unreleased)
 
 ### Added
-* Basic task API
 * List payment methods through the Accounts API 
 * Cloud accounts API
-* Basic subscription API
+* Subscription API
 * Basic database API
 
 ### Changed

--- a/client.go
+++ b/client.go
@@ -14,7 +14,6 @@ import (
 	"github.com/RedisLabs/rediscloud-go-api/service/cloud_accounts"
 	"github.com/RedisLabs/rediscloud-go-api/service/databases"
 	"github.com/RedisLabs/rediscloud-go-api/service/subscriptions"
-	"github.com/RedisLabs/rediscloud-go-api/service/task"
 )
 
 type Client struct {
@@ -22,7 +21,6 @@ type Client struct {
 	CloudAccount *cloud_accounts.API
 	Database     *databases.API
 	Subscription *subscriptions.API
-	Task         *task.API
 }
 
 func NewClient(configs ...Option) (*Client, error) {
@@ -48,7 +46,7 @@ func NewClient(configs ...Option) (*Client, error) {
 		return nil, err
 	}
 
-	t := task.NewAPI(client, config.logger)
+	t := internal.NewAPI(client, config.logger)
 
 	a := account.NewAPI(client)
 	c := cloud_accounts.NewAPI(client, t, config.logger)
@@ -60,7 +58,6 @@ func NewClient(configs ...Option) (*Client, error) {
 		CloudAccount: c,
 		Database:     d,
 		Subscription: s,
-		Task:         t,
 	}, nil
 }
 

--- a/database_test.go
+++ b/database_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDatabase_List(t *testing.T) {
-	s := httptest.NewServer(testServer("apiKey", "secret", getRequest(t, "/subscriptions/23456/databases?limit=100&offset=0", `{
+	s := httptest.NewServer(testServer("apiKey", "secret", getRequestWithQuery(t, "/subscriptions/23456/databases", map[string][]string{"limit": {"100"}, "offset": {"0"}}, `{
   "accountId": 2,
   "subscription": [
     {

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -24,68 +25,43 @@ func NewHttpClient(client *http.Client, baseUrl string) (*HttpClient, error) {
 }
 
 func (c *HttpClient) Get(ctx context.Context, name, path string, responseBody interface{}) error {
-	return c.withoutRequestBody(ctx, http.MethodGet, name, path, responseBody)
+	return c.connection(ctx, http.MethodGet, name, path, nil, nil, responseBody)
+}
+
+func (c *HttpClient) GetWithQuery(ctx context.Context, name, path string, query url.Values, responseBody interface{}) error {
+	return c.connection(ctx, http.MethodGet, name, path, query, nil, responseBody)
 }
 
 func (c *HttpClient) Put(ctx context.Context, name, path string, requestBody interface{}, responseBody interface{}) error {
-	return c.withRequestBody(ctx, http.MethodPut, name, path, requestBody, responseBody)
+	return c.connection(ctx, http.MethodPut, name, path, nil, requestBody, responseBody)
 }
 
 func (c *HttpClient) Post(ctx context.Context, name, path string, requestBody interface{}, responseBody interface{}) error {
-	return c.withRequestBody(ctx, http.MethodPost, name, path, requestBody, responseBody)
+	return c.connection(ctx, http.MethodPost, name, path, nil, requestBody, responseBody)
 }
 
 func (c *HttpClient) Delete(ctx context.Context, name, path string, responseBody interface{}) error {
-	return c.withoutRequestBody(ctx, http.MethodDelete, name, path, responseBody)
+	return c.connection(ctx, http.MethodDelete, name, path, nil, nil, responseBody)
 }
 
-func (c *HttpClient) withoutRequestBody(ctx context.Context, method, name, path string, responseBody interface{}) error {
+func (c *HttpClient) connection(ctx context.Context, method, name, path string, query url.Values, requestBody interface{}, responseBody interface{}) error {
 	parsed := new(url.URL)
 	*parsed = *c.baseUrl
 
 	parsed.Path += path
+	if query != nil {
+		parsed.RawQuery = query.Encode()
+	}
 
 	u := parsed.String()
 
-	request, err := http.NewRequestWithContext(ctx, method, u, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request to %s: %w", name, err)
-	}
-
-	response, err := c.client.Do(request)
-	if err != nil {
-		return fmt.Errorf("failed to %s: %w", name, err)
-	}
-
-	defer response.Body.Close()
-
-	if response.StatusCode > 299 {
-		body, _ := ioutil.ReadAll(response.Body)
-		return &HTTPError{
-			Name:       name,
-			StatusCode: response.StatusCode,
-			Body:       body,
+	var body io.Reader
+	if requestBody != nil {
+		buf := bytes.NewBuffer(nil)
+		if err := json.NewEncoder(buf).Encode(requestBody); err != nil {
+			return fmt.Errorf("failed to encode request for %s: %w", name, err)
 		}
-	}
-
-	if err := json.NewDecoder(response.Body).Decode(&responseBody); err != nil {
-		return fmt.Errorf("failed to decode response to %s: %w", name, err)
-	}
-
-	return nil
-}
-
-func (c *HttpClient) withRequestBody(ctx context.Context, method, name, path string, requestBody interface{}, responseBody interface{}) error {
-	parsed := new(url.URL)
-	*parsed = *c.baseUrl
-
-	parsed.Path += path
-
-	u := parsed.String()
-
-	body := bytes.NewBuffer(nil)
-	if err := json.NewEncoder(body).Encode(requestBody); err != nil {
-		return fmt.Errorf("failed to encode request for %s: %w", name, err)
+		body = buf
 	}
 
 	request, err := http.NewRequestWithContext(ctx, method, u, body)

--- a/internal/model.go
+++ b/internal/model.go
@@ -1,34 +1,33 @@
-package task
+package internal
 
 import (
 	"encoding/json"
 	"fmt"
 	"regexp"
 
-	"github.com/RedisLabs/rediscloud-go-api/internal"
 	"github.com/RedisLabs/rediscloud-go-api/redis"
 )
 
-type Task struct {
+type task struct {
 	CommandType *string   `json:"commandType,omitempty"`
 	Description *string   `json:"description,omitempty"`
 	Status      *string   `json:"status,omitempty"`
 	ID          *string   `json:"taskId,omitempty"`
-	Response    *Response `json:"response,omitempty"`
+	Response    *response `json:"response,omitempty"`
 }
 
-func (o Task) String() string {
-	return internal.ToString(o)
+func (o task) String() string {
+	return ToString(o)
 }
 
-type Response struct {
+type response struct {
 	ID       *int             `json:"resourceId,omitempty"`
 	Resource *json.RawMessage `json:"resource,omitempty"`
 	Error    *Error           `json:"error,omitempty"`
 }
 
-func (o Response) String() string {
-	return internal.ToString(o)
+func (o response) String() string {
+	return ToString(o)
 }
 
 type Error struct {
@@ -38,7 +37,7 @@ type Error struct {
 }
 
 func (o Error) String() string {
-	return internal.ToString(o)
+	return ToString(o)
 }
 
 func (e *Error) StatusCode() string {

--- a/internal/model_test.go
+++ b/internal/model_test.go
@@ -1,4 +1,4 @@
-package task
+package internal
 
 import (
 	"testing"

--- a/service/task/task.go
+++ b/service/task/task.go
@@ -1,5 +1,0 @@
-// Package task allows the interaction task resource. Tasks are created by other resources to execute various actions
-// that can take significant about of time. All APIs within this package will eventually be migrated to `internal/`
-// once the other resources have been implemented in the SDK, as these other resources will provide an interface
-// which wraps this package.
-package task

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestSubscription_Create(t *testing.T) {
 	expected := 1235
+	// Also test that the task API will poll for the finished task
 	s := httptest.NewServer(testServer("key", "secret", postRequest(t, "/subscriptions", `{
   "name": "Test subscription",
   "dryRun": false,
@@ -59,8 +60,32 @@ func TestSubscription_Create(t *testing.T) {
       "type": "GET"
     }
   }
+}`), getRequest(t, "/tasks/task-id", `{
+  "taskId": "task-id",
+  "commandType": "subscriptionCreateRequest",
+  "status": "initialized",
+  "timestamp": "2020-10-28T09:58:16.798Z",
+  "response": {},
+  "_links": {
+    "self": {
+      "href": "https://example.com",
+      "type": "GET"
+    }
+  }
+}`), getRequest(t, "/tasks/task-id", `{
+  "taskId": "task-id",
+  "commandType": "subscriptionCreateRequest",
+  "status": "processing-in-progress",
+  "timestamp": "2020-10-28T09:58:16.798Z",
+  "response": {},
+  "_links": {
+    "self": {
+      "href": "https://example.com",
+      "type": "GET"
+    }
+  }
 }`), getRequest(t, "/tasks/task-id", fmt.Sprintf(`{
-  "taskId": "e02b40d6-1395-4861-a3b9-ecf829d835fd",
+  "taskId": "task-id",
   "commandType": "subscriptionCreateRequest",
   "status": "processing-completed",
   "timestamp": "2020-10-28T09:58:16.798Z",


### PR DESCRIPTION
Move the Task API into `internal/` as the other APIs - subscription, database, etc - wrap the Task API and provide the user with a single entry point, rather than having to worry about polling for a task to finish.

Also fix the list database functionality and reduce some needless code duplication.