### PR TITLE
Expand the database API to cover all f the endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 * List payment methods through the Accounts API 
 * Cloud accounts API
 * Subscription API
-* Basic database API
+* Database API
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -21,20 +21,23 @@ import (
 	"fmt"
 
 	rediscloud_api "github.com/RedisLabs/rediscloud-go-api"
+	"github.com/RedisLabs/rediscloud-go-api/service/subscriptions"
 )
 
 func main() {
-	// The client will use the credentials from `REDISCLOUD_API_KEY` and `REDISCLOUD_SECRET_KEY` by default
+	// The client will use the credentials from `REDISCLOUD_ACCESS_KEY` and `REDISCLOUD_SECRET_KEY` by default
 	client, err := rediscloud_api.NewClient()
 	if err != nil {
 		panic(err)
 	}
 
-	task, err := client.Task.Get(context.TODO(), "task-uuid")
+	id, err := client.Subscription.Create(context.TODO(), subscriptions.CreateSubscription{
+		// ...
+	})
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("Found task: %#v", task)
+	fmt.Printf("Created subscription: %d", id)
 }
 ```

--- a/service/cloud_accounts/service.go
+++ b/service/cloud_accounts/service.go
@@ -3,8 +3,6 @@ package cloud_accounts
 import (
 	"context"
 	"fmt"
-
-	"github.com/RedisLabs/rediscloud-go-api/redis"
 )
 
 type Log interface {
@@ -42,7 +40,7 @@ func (a *API) Create(ctx context.Context, account CreateCloudAccount) (int, erro
 
 	a.logger.Printf("Waiting for task %s to finish creating the cloud account", response)
 
-	id, err := a.task.WaitForResourceId(ctx, redis.StringValue(response.ID))
+	id, err := a.task.WaitForResourceId(ctx, *response.ID)
 	if err != nil {
 		return 0, err
 	}
@@ -69,7 +67,7 @@ func (a *API) Update(ctx context.Context, id int, account UpdateCloudAccount) er
 
 	a.logger.Printf("Waiting for cloud account %d to finish being updated", id)
 
-	err := a.task.Wait(ctx, redis.StringValue(response.ID))
+	err := a.task.Wait(ctx, *response.ID)
 	if err != nil {
 		return fmt.Errorf("failed when updating account %d: %w", id, err)
 	}
@@ -86,7 +84,7 @@ func (a *API) Delete(ctx context.Context, id int) error {
 
 	a.logger.Printf("Waiting for cloud account %d to finish being deleted", id)
 
-	if err := a.task.Wait(ctx, redis.StringValue(response.ID)); err != nil {
+	if err := a.task.Wait(ctx, *response.ID); err != nil {
 		return fmt.Errorf("failed when deleting account %d: %w", id, err)
 	}
 

--- a/service/databases/model.go
+++ b/service/databases/model.go
@@ -14,6 +14,58 @@ func (o taskResponse) String() string {
 	return internal.ToString(o)
 }
 
+type CreateDatabase struct {
+	DryRun                              *bool                        `json:"dryRun,omitempty"`
+	Name                                *string                      `json:"name,omitempty"`
+	Protocol                            *string                      `json:"protocol,omitempty"`
+	MemoryLimitInGB                     *float64                     `json:"memoryLimitInGb,omitempty"`
+	SupportOSSClusterAPI                *bool                        `json:"supportOSSClusterApi,omitempty"`
+	UseExternalEndpointForOSSClusterAPI *bool                        `json:"useExternalEndpointForOSSClusterApi,omitempty"`
+	DataPersistence                     *string                      `json:"dataPersistence,omitempty"`
+	DataEvictionPolicy                  *string                      `json:"dataEvictionPolicy,omitempty"`
+	Replication                         *bool                        `json:"replication,omitempty"`
+	ThroughputMeasurement               *CreateThroughputMeasurement `json:"throughputMeasurement,omitempty"`
+	AverageItemSizeInBytes              *int                         `json:"averageItemSizeInBytes,omitempty"`
+	ReplicaOf                           []*string                    `json:"replicaOf,omitempty"`
+	PeriodicBackupPath                  *string                      `json:"periodicBackupPath,omitempty"`
+	SourceIP                            []*string                    `json:"sourceIp,omitempty"`
+	ClientSSLCertificate                *string                      `json:"clientSslCertificate,omitempty"`
+	Password                            *string                      `json:"password,omitempty"`
+	Alerts                              []*CreateAlert               `json:"alerts,omitempty"`
+	Modules                             []*CreateModule              `json:"modules,omitempty"`
+}
+
+func (o CreateDatabase) String() string {
+	return internal.ToString(o)
+}
+
+type CreateThroughputMeasurement struct {
+	By    *string `json:"by,omitempty"`
+	Value *int    `json:"value,omitempty"`
+}
+
+func (o CreateThroughputMeasurement) String() string {
+	return internal.ToString(o)
+}
+
+type CreateAlert struct {
+	Name  *string `json:"name,omitempty"`
+	Value *int    `json:"value,omitempty"`
+}
+
+func (o CreateAlert) String() string {
+	return internal.ToString(o)
+}
+
+type CreateModule struct {
+	Name       *string            `json:"name,omitempty"`
+	Parameters map[string]*string `json:"parameters,omitempty"`
+}
+
+func (o CreateModule) String() string {
+	return internal.ToString(o)
+}
+
 type Database struct {
 	ID                     *int        `json:"databaseId,omitempty"`
 	Name                   *string     `json:"name,omitempty"`
@@ -92,6 +144,56 @@ func (o Alert) String() string {
 	return internal.ToString(o)
 }
 
+type UpdateDatabase struct {
+	DryRun                              *bool                        `json:"dryRun,omitempty"`
+	Name                                *string                      `json:"name,omitempty"`
+	MemoryLimitInGB                     *float64                     `json:"memoryLimitInGb,omitempty"`
+	SupportOSSClusterAPI                *bool                        `json:"supportOSSClusterApi,omitempty"`
+	UseExternalEndpointForOSSClusterAPI *bool                        `json:"useExternalEndpointForOSSClusterApi,omitempty"`
+	DataEvictionPolicy                  *string                      `json:"dataEvictionPolicy,omitempty"`
+	Replication                         *bool                        `json:"replication,omitempty"`
+	ThroughputMeasurement               *UpdateThroughputMeasurement `json:"throughputMeasurement,omitempty"`
+	RegexRules                          []*string                    `json:"regexRules,omitempty"`
+	DataPersistence                     *string                      `json:"dataPersistence,omitempty"`
+	ReplicaOf                           []*string                    `json:"replicaOf,omitempty"`
+	PeriodicBackupPath                  *string                      `json:"periodicBackupPath,omitempty"`
+	SourceIP                            []*string                    `json:"sourceIp,omitempty"`
+	ClientSSLCertificate                *string                      `json:"clientSslCertificate,omitempty"`
+	Password                            *string                      `json:"password,omitempty"`
+	Alerts                              []*UpdateAlert               `json:"alerts,omitempty"`
+}
+
+func (o UpdateDatabase) String() string {
+	return internal.ToString(o)
+}
+
+type UpdateThroughputMeasurement struct {
+	By    *string `json:"by,omitempty"`
+	Value *int    `json:"value,omitempty"`
+}
+
+func (o UpdateThroughputMeasurement) String() string {
+	return internal.ToString(o)
+}
+
+type UpdateAlert struct {
+	Name  *string `json:"name,omitempty"`
+	Value *int    `json:"value,omitempty"`
+}
+
+func (o UpdateAlert) String() string {
+	return internal.ToString(o)
+}
+
+type Import struct {
+	SourceType    *string   `json:"sourceType,omitempty"`
+	ImportFromURI []*string `json:"importFromUri,omitempty"`
+}
+
+func (o Import) String() string {
+	return internal.ToString(o)
+}
+
 type listDatabaseResponse struct {
 	Subscription []*listDbSubscription `json:"subscription,omitempty"`
 }
@@ -145,7 +247,7 @@ func DataPersistenceValues() []string {
 	}
 }
 
-func DataEvictionValues() []string {
+func DataEvictionPolicyValues() []string {
 	return []string{
 		"allkeys-lru",
 		"allkeys-lfu",
@@ -155,5 +257,16 @@ func DataEvictionValues() []string {
 		"volatile-random",
 		"volatile-ttl",
 		"noeviction",
+	}
+}
+
+func SourceTypeValues() []string {
+	return []string{
+		"http",
+		"redis",
+		"ftp",
+		"aws-s3",
+		"azure-blob-storage",
+		"google-blob-storage",
 	}
 }

--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -139,22 +139,22 @@ func (o Networking) String() string {
 	return internal.ToString(o)
 }
 
-type CIDRWhitelist struct {
+type CIDRAllowlist struct {
 	CIDRIPs          []*string   `json:"cidr_ips,omitempty"`
 	SecurityGroupIDs []*string   `json:"security_group_ids,omitempty"`
 	Errors           interface{} `json:"errors,omitempty"` // TODO the structure of this is undocumented
 }
 
-func (o CIDRWhitelist) String() string {
+func (o CIDRAllowlist) String() string {
 	return internal.ToString(o)
 }
 
-type UpdateCIDRWhitelist struct {
+type UpdateCIDRAllowlist struct {
 	CIDRIPs          []*string `json:"cidrIps,omitempty"`
 	SecurityGroupIDs []*string `json:"securityGroupIds,omitempty"`
 }
 
-func (o UpdateCIDRWhitelist) String() string {
+func (o UpdateCIDRAllowlist) String() string {
 	return internal.ToString(o)
 }
 

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -508,10 +508,10 @@ func TestSubscription_GetCIDRWhitelist(t *testing.T) {
 	subject, err := clientFromTestServer(s, "apiKey", "secret")
 	require.NoError(t, err)
 
-	actual, err := subject.Subscription.GetCIDRWhitelist(context.TODO(), 12356)
+	actual, err := subject.Subscription.GetCIDRAllowlist(context.TODO(), 12356)
 	require.NoError(t, err)
 
-	assert.Equal(t, &subscriptions.CIDRWhitelist{
+	assert.Equal(t, &subscriptions.CIDRAllowlist{
 		CIDRIPs:          redis.StringSlice("1", "2", "3"),
 		SecurityGroupIDs: redis.StringSlice("4", "5", "6"),
 	}, actual)
@@ -556,7 +556,7 @@ func TestSubscription_UpdateCIDRWhitelist(t *testing.T) {
 	subject, err := clientFromTestServer(s, "apiKey", "secret")
 	require.NoError(t, err)
 
-	err = subject.Subscription.UpdateCIDRWhitelist(context.TODO(), 12356, subscriptions.UpdateCIDRWhitelist{
+	err = subject.Subscription.UpdateCIDRAllowlist(context.TODO(), 12356, subscriptions.UpdateCIDRAllowlist{
 		CIDRIPs:          redis.StringSlice("6", "5"),
 		SecurityGroupIDs: redis.StringSlice("a", "b"),
 	})

--- a/util_test.go
+++ b/util_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func clientFromTestServer(s *httptest.Server, apiKey string, secretKey string) (*Client, error) {
-	return NewClient(LogRequests(true), BaseUrl(s.URL), Auth(apiKey, secretKey), Transporter(s.Client().Transport))
+	return NewClient(LogRequests(true), BaseURL(s.URL), Auth(apiKey, secretKey), Transporter(s.Client().Transport))
 }
 
 func testServer(apiKey, secretKey string, mockedResponses ...endpointRequest) http.HandlerFunc {
@@ -123,6 +123,15 @@ func postRequest(t *testing.T, path string, request string, body string) endpoin
 		body:        body,
 		requestBody: &request,
 		t:           t,
+	}
+}
+
+func postRequestWithNoRequest(t *testing.T, path string, body string) endpointRequest {
+	return endpointRequest{
+		method: http.MethodPost,
+		path:   path,
+		body:   body,
+		t:      t,
 	}
 }
 


### PR DESCRIPTION
Add support for creating, updating, backing up and importing databases.

Also:
* Add short descriptions for most public functions
* Replace 'whitelist' with 'allowlist'
* Replace `redis.String` with a simple dereference when getting the task ID from a response. The argument for this being that it'd be better for the program to crash rather accidentally call the 'list tasks' endpoint
* Change the default logger to be a simple struct so that the Golang default logger can be reused