### PR TITLE
Support task eventual consistency

### DIFF
--- a/subscription_test.go
+++ b/subscription_test.go
@@ -60,7 +60,7 @@ func TestSubscription_Create(t *testing.T) {
       "type": "GET"
     }
   }
-}`), getRequest(t, "/tasks/task-id", `{
+}`), getRequestWithStatus(t, "/tasks/task-id", 404, ""), getRequest(t, "/tasks/task-id", `{
   "taskId": "task-id",
   "commandType": "subscriptionCreateRequest",
   "status": "initialized",

--- a/task_test.go
+++ b/task_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTaskErrorsGetUnwraped(t *testing.T) {
+func TestTaskErrorsGetUnwrapped(t *testing.T) {
 	s := httptest.NewServer(testServer("key", "secret", deleteRequest(t, "/cloud-accounts/1", `{
   "taskId": "task",
   "commandType": "cloudAccountDeleteRequest",
@@ -55,4 +55,41 @@ func TestTaskErrorsGetUnwraped(t *testing.T) {
 		Description: redis.String("Payment info was not found for subscription. Use 'GET /payment-methods' to lookup valid payment methods for current Account"),
 		Status:      redis.String("400 BAD_REQUEST"),
 	}, errors.Unwrap(err))
+}
+
+func TestTask_GivesUpAfterThree404s(t *testing.T) {
+	s := httptest.NewServer(testServer("key", "secret", deleteRequest(t, "/cloud-accounts/1", `{
+  "taskId": "task",
+  "commandType": "cloudAccountDeleteRequest",
+  "status": "received",
+  "description": "Task request received and is being queued for processing.",
+  "timestamp": "2020-11-02T09:05:34.3Z",
+  "_links": {
+    "task": {
+      "href": "https://example.org",
+      "title": "getTaskStatusUpdates",
+      "type": "GET"
+    }
+  }
+}`), getRequest(t, "/tasks/task", `{
+  "taskId": "e02b40d6-1395-4861-a3b9-ecf829d835fd",
+  "commandType": "cloudAccountDeleteRequest",
+  "status": "initialized",
+  "timestamp": "2020-10-28T09:58:16.798Z",
+  "response": {},
+  "_links": {
+    "self": {
+      "href": "https://example.com",
+      "type": "GET"
+    }
+  }
+}`), getRequestWithStatus(t, "/tasks/task", 404, ""),
+		getRequestWithStatus(t, "/tasks/task", 404, ""),
+		getRequestWithStatus(t, "/tasks/task", 404, "")))
+
+	subject, err := clientFromTestServer(s, "key", "secret")
+	require.NoError(t, err)
+
+	err = subject.CloudAccount.Delete(context.TODO(), 1)
+	assert.Error(t, err)
 }

--- a/util_test.go
+++ b/util_test.go
@@ -122,6 +122,16 @@ func getRequestWithQueryAndStatus(t *testing.T, path string, query url.Values, s
 	}
 }
 
+func getRequestWithStatus(t *testing.T, path string, status int, body string) endpointRequest {
+	return endpointRequest{
+		method: http.MethodGet,
+		path:   path,
+		body:   body,
+		status: status,
+		t:      t,
+	}
+}
+
 func deleteRequest(t *testing.T, path string, body string) endpointRequest {
 	return endpointRequest{
 		method: http.MethodDelete,


### PR DESCRIPTION
It is possible for the task API to return 404 for a newly created task, so allow two 404 responses for a task before giving up on the third one.