### PR TITLE
Wrap 404 error returned for a subscription

### DIFF
--- a/service/databases/model.go
+++ b/service/databases/model.go
@@ -218,6 +218,10 @@ const (
 	StatusDraft = "draft"
 	// Pending value of the `Status` field in `Database`
 	StatusPending = "pending"
+	// RCP change pending value of the `Status` field in `Database`
+	StatusRCPChangePending = "rcp-change-pending"
+	// RCP draft value of the `Status` field in `Database`
+	StatusRCPDraft = "rcp-draft"
 	// RCP active change draft value of the `Status` field in `Database`
 	StatusRCPActiveChangeDraft = "rcp-active-change-draft"
 	// Active change draft value of the `Status` field in `Database`

--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -1,6 +1,8 @@
 package subscriptions
 
 import (
+	"fmt"
+
 	"github.com/RedisLabs/rediscloud-go-api/internal"
 )
 
@@ -188,6 +190,14 @@ type taskResponse struct {
 
 func (o taskResponse) String() string {
 	return internal.ToString(o)
+}
+
+type NotFound struct {
+	id int
+}
+
+func (f *NotFound) Error() string {
+	return fmt.Sprintf("subscription %d not found", f.id)
 }
 
 const (

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -394,6 +394,18 @@ func TestSubscription_Get(t *testing.T) {
 	}, actual)
 }
 
+func TestSubscription_Get_wraps404Error(t *testing.T) {
+	s := httptest.NewServer(testServer("apiKey", "secret", getRequestWithStatus(t, "/subscriptions/123", 404, "")))
+
+	subject, err := clientFromTestServer(s, "apiKey", "secret")
+	require.NoError(t, err)
+
+	actual, err := subject.Subscription.Get(context.TODO(), 123)
+
+	assert.Nil(t, actual)
+	assert.IsType(t, &subscriptions.NotFound{}, err)
+}
+
 func TestSubscription_Update(t *testing.T) {
 	s := httptest.NewServer(testServer("key", "secret", putRequest(t, "/subscriptions/1234", `{
   "name": "test",


### PR DESCRIPTION
Allow users of the SDK to easily identify when the problem with the subscription being used is that it doesn't exist. This is useful when waiting for a subscription to be completely deleted.