### PR TITLE
Give missing cloud accounts a distinctive error type

### DIFF
--- a/cloud_account_test.go
+++ b/cloud_account_test.go
@@ -147,6 +147,18 @@ func TestCloudAccount_Get(t *testing.T) {
 	}, actual)
 }
 
+func TestCloudAccount_Get_wraps404(t *testing.T) {
+	s := httptest.NewServer(testServer("apiKey", "secret", getRequestWithStatus(t, "/cloud-accounts/98765", 404, "")))
+
+	subject, err := clientFromTestServer(s, "apiKey", "secret")
+	require.NoError(t, err)
+
+	actual, err := subject.CloudAccount.Get(context.TODO(), 98765)
+
+	assert.Nil(t, actual)
+	assert.IsType(t, &cloud_accounts.NotFound{}, err)
+}
+
 func TestCloudAccount_List(t *testing.T) {
 	s := httptest.NewServer(testServer("apiKey", "secret", getRequest(t, "/cloud-accounts", `{
   "accountId": 1245,

--- a/service/cloud_accounts/model.go
+++ b/service/cloud_accounts/model.go
@@ -1,6 +1,8 @@
 package cloud_accounts
 
 import (
+	"fmt"
+
 	"github.com/RedisLabs/rediscloud-go-api/internal"
 )
 
@@ -29,6 +31,14 @@ type UpdateCloudAccount struct {
 
 func (o UpdateCloudAccount) String() string {
 	return internal.ToString(o)
+}
+
+type NotFound struct {
+	id int
+}
+
+func (f *NotFound) Error() string {
+	return fmt.Sprintf("cloud account %d not found", f.id)
 }
 
 type listCloudAccounts struct {


### PR DESCRIPTION
Return a specific error type if the cloud account couldn't be found