### PR TITLE
Updates the VPCPeering model with additional attributes

### DIFF
--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -178,13 +178,17 @@ type listVpcPeering struct {
 }
 
 type VPCPeering struct {
-	ID            *int    `json:"vpcPeeringId,omitempty"`
-	Status        *string `json:"status,omitempty"`
-	AWSAccountID  *string `json:"awsAccountId,omitempty"`
-	VPCId         *string `json:"vpcUid,omitempty"`
-	VPCCidr       *string `json:"vpcCidr,omitempty"`
-	GCPProjectUID *string `json:"projectUid,omitempty"`
-	NetworkName   *string `json:"networkName,omitempty"`
+	ID               *int    `json:"vpcPeeringId,omitempty"`
+	Status           *string `json:"status,omitempty"`
+	AWSAccountID     *string `json:"awsAccountId,omitempty"`
+	AWSPeeringId     *string `json:"awsPeeringUid,omitempty"`
+	VPCId            *string `json:"vpcUid,omitempty"`
+	VPCCidr          *string `json:"vpcCidr,omitempty"`
+	GCPProjectUID    *string `json:"projectUid,omitempty"`
+	NetworkName      *string `json:"networkName,omitempty"`
+	RedisProjectUid  *string `json:"redisProjectUid,omitempty"`
+	RedisNetworkName *string `json:"redisNetworkName,omitempty"`
+	CloudPeeringId   *string `json:"cloudPeeringId,omitempty"`
 }
 
 func (o VPCPeering) String() string {

--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -181,14 +181,14 @@ type VPCPeering struct {
 	ID               *int    `json:"vpcPeeringId,omitempty"`
 	Status           *string `json:"status,omitempty"`
 	AWSAccountID     *string `json:"awsAccountId,omitempty"`
-	AWSPeeringId     *string `json:"awsPeeringUid,omitempty"`
+	AWSPeeringID     *string `json:"awsPeeringUid,omitempty"`
 	VPCId            *string `json:"vpcUid,omitempty"`
 	VPCCidr          *string `json:"vpcCidr,omitempty"`
 	GCPProjectUID    *string `json:"projectUid,omitempty"`
 	NetworkName      *string `json:"networkName,omitempty"`
-	RedisProjectUid  *string `json:"redisProjectUid,omitempty"`
+	RedisProjectUID  *string `json:"redisProjectUid,omitempty"`
 	RedisNetworkName *string `json:"redisNetworkName,omitempty"`
-	CloudPeeringId   *string `json:"cloudPeeringId,omitempty"`
+	CloudPeeringID   *string `json:"cloudPeeringId,omitempty"`
 }
 
 func (o VPCPeering) String() string {

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -597,13 +597,16 @@ func TestSubscription_ListVPCPeering(t *testing.T) {
   "response": {
     "resourceId" : 12356,
     "resource" : {
-      "peerings" : [ {
-        "vpcPeeringId" : 10,
-        "awsAccountId" : "4291",
-        "vpcUid" : "vpc-deadbeef",
-        "vpcCidr" : "10.0.0.0/24",
-        "status" : "done"
-      } ]
+      "peerings" : [
+		{
+          "vpcPeeringId": 10,
+          "awsAccountId": "4291",
+          "vpcUid": "vpc-deadbeef",
+          "vpcCidr": "10.0.0.0/24",
+          "awsPeeringUid": "pcx-0123456789",
+          "status": "done"
+		}
+	  ]
     }
   },
   "_links": {
@@ -626,6 +629,7 @@ func TestSubscription_ListVPCPeering(t *testing.T) {
 			AWSAccountID: redis.String("4291"),
 			VPCId:        redis.String("vpc-deadbeef"),
 			VPCCidr:      redis.String("10.0.0.0/24"),
+			AWSPeeringID: redis.String("pcx-0123456789"),
 			Status:       redis.String("done"),
 		},
 	}, actual)


### PR DESCRIPTION
Updates the SDK VPC Peerring model with GCP specific fields and adds an additional field for AWS.  The names match the API names.  The branch has been used with the `dev/implement-missing-vpc-peering-attributes` on the Terraform provider.