### PR TITLE
Add 'Content-Type: application/json' into all requests to the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.1.6 (Unreleased)
 
+### Added
+
+* Include "Content-Type: application/json" in the header of all requests to the API.
 
 ## 0.1.5 (December 9 2021)
 

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -65,6 +65,10 @@ func (c *HttpClient) connection(ctx context.Context, method, name, path string, 
 	}
 
 	request, err := http.NewRequestWithContext(ctx, method, u, body)
+
+	// The API expects this entry in the header in all requests.
+	request.Header.Set("Content-Type", "application/json")
+	
 	if err != nil {
 		return fmt.Errorf("failed to create request to %s: %w", name, err)
 	}

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -68,7 +68,7 @@ func (c *HttpClient) connection(ctx context.Context, method, name, path string, 
 
 	// The API expects this entry in the header in all requests.
 	request.Header.Set("Content-Type", "application/json")
-	
+
 	if err != nil {
 		return fmt.Errorf("failed to create request to %s: %w", name, err)
 	}

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package rediscloud_api


### PR DESCRIPTION
This fixes the issue in the TF provider where the API is throwing the following error:

  "message" : "Content type 'application/octet-stream' not supported",
