### PR TITLE
Remove persistent_storage_encryption from the API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
-## 0.1.8 (unreleased)
-
-## 0.1.7 (April X 2022)
+## 0.1.7 (unreleased)
 
 ### Removed
 
-* Removed the PersistentStorageEncryption field from the API calls.
+* Removed the PersistentStorageEncryption (deprecated) field from the API calls.
 
 ## 0.1.6 (January 14 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
-## 0.1.7 (unreleased)
+## 0.1.8 (unreleased)
+
+## 0.1.7 (April X 2022)
+
+### Removed
+
+* Removed the PersistentStorageEncryption field from the API calls.
 
 ## 0.1.6 (January 14 2022)
 

--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -11,7 +11,6 @@ type CreateSubscription struct {
 	DryRun                      *bool                  `json:"dryRun,omitempty"`
 	PaymentMethodID             *int                   `json:"paymentMethodId,omitempty"`
 	MemoryStorage               *string                `json:"memoryStorage,omitempty"`
-	PersistentStorageEncryption *bool                  `json:"persistentStorageEncryption,omitempty"`
 	CloudProviders              []*CreateCloudProvider `json:"cloudProviders,omitempty"`
 	Databases                   []*CreateDatabase      `json:"databases,omitempty"`
 }

--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -7,12 +7,12 @@ import (
 )
 
 type CreateSubscription struct {
-	Name                        *string                `json:"name,omitempty"`
-	DryRun                      *bool                  `json:"dryRun,omitempty"`
-	PaymentMethodID             *int                   `json:"paymentMethodId,omitempty"`
-	MemoryStorage               *string                `json:"memoryStorage,omitempty"`
-	CloudProviders              []*CreateCloudProvider `json:"cloudProviders,omitempty"`
-	Databases                   []*CreateDatabase      `json:"databases,omitempty"`
+	Name            *string                `json:"name,omitempty"`
+	DryRun          *bool                  `json:"dryRun,omitempty"`
+	PaymentMethodID *int                   `json:"paymentMethodId,omitempty"`
+	MemoryStorage   *string                `json:"memoryStorage,omitempty"`
+	CloudProviders  []*CreateCloudProvider `json:"cloudProviders,omitempty"`
+	Databases       []*CreateDatabase      `json:"databases,omitempty"`
 }
 
 func (o CreateSubscription) String() string {

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -20,7 +20,6 @@ func TestSubscription_Create(t *testing.T) {
   "dryRun": false,
   "paymentMethodId": 2,
   "memoryStorage": "ram",
-  "persistentStorageEncryption": false,
   "cloudProviders": [
     {
       "provider": "AWS",
@@ -108,7 +107,6 @@ func TestSubscription_Create(t *testing.T) {
 		DryRun:                      redis.Bool(false),
 		PaymentMethodID:             redis.Int(2),
 		MemoryStorage:               redis.String("ram"),
-		PersistentStorageEncryption: redis.Bool(false),
 		CloudProviders: []*subscriptions.CreateCloudProvider{
 			{
 				Provider:       redis.String("AWS"),

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -103,10 +103,10 @@ func TestSubscription_Create(t *testing.T) {
 	require.NoError(t, err)
 
 	actual, err := subject.Subscription.Create(context.TODO(), subscriptions.CreateSubscription{
-		Name:                        redis.String("Test subscription"),
-		DryRun:                      redis.Bool(false),
-		PaymentMethodID:             redis.Int(2),
-		MemoryStorage:               redis.String("ram"),
+		Name:            redis.String("Test subscription"),
+		DryRun:          redis.Bool(false),
+		PaymentMethodID: redis.Int(2),
+		MemoryStorage:   redis.String("ram"),
 		CloudProviders: []*subscriptions.CreateCloudProvider{
 			{
 				Provider:       redis.String("AWS"),


### PR DESCRIPTION
The attribute is deprecated, so there's no need to send it in the API calls (`SubscriptionCreateRequest`).