### PR TITLE
fix: catch 404 errors in AA regions requests

### DIFF
--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -272,11 +272,11 @@ func (o taskResponse) String() string {
 }
 
 type NotFound struct {
-	id int
+	ID int
 }
 
 func (f *NotFound) Error() string {
-	return fmt.Sprintf("subscription %d not found", f.id)
+	return fmt.Sprintf("subscription %d not found", f.ID)
 }
 
 const (

--- a/service/subscriptions/service.go
+++ b/service/subscriptions/service.go
@@ -269,7 +269,7 @@ func (a *API) DeleteActiveActiveVPCPeering(ctx context.Context, subscription int
 
 func wrap404Error(id int, err error) error {
 	if v, ok := err.(*internal.HTTPError); ok && v.StatusCode == http.StatusNotFound {
-		return &NotFound{id: id}
+		return &NotFound{ID: id}
 	}
 	return err
 }


### PR DESCRIPTION
The subscriptions requests return a custom error type when the API returns a 404. The regions requests can also receive 404s when the subscription doesn't exist, so should also return the custom error type. Given that this corresponds to subscription not found errors, I have reused the same custom type in the subscriptions package.

This change results in a minor change to the existing error type, but it is not a breaking change as it changes a property from private to public, so nothing could be depending on it already