### PR TITLE
Add support for port number, backup & CIDRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
 * Dependencies for CI and Testing
 
+### Added
+* Add support for port number and backup to databases
+* Add support for multiple CIDR ranges when peering
+
 ## 0.1.9 (July 5 2022)
 ### Added 
 

--- a/service/databases/model.go
+++ b/service/databases/model.go
@@ -35,6 +35,8 @@ type CreateDatabase struct {
 	Alerts                              []*CreateAlert               `json:"alerts,omitempty"`
 	Modules                             []*CreateModule              `json:"modules,omitempty"`
 	EnableTls                           *bool                        `json:"enableTls,omitempty"`
+	PortNumber                          *int                         `json:"port,omitempty"`
+	RemoteBackup                        *DatabaseBackupConfig        `json:"remoteBackup,omitempty"`
 }
 
 func (o CreateDatabase) String() string {
@@ -93,6 +95,7 @@ type Database struct {
 	PrivateEndpoint        *string     `json:"privateEndpoint,omitempty"`
 	PublicEndpoint         *string     `json:"publicEndpoint,omitempty"`
 	RedisVersionCompliance *string     `json:"redisVersionCompliance,omitempty"`
+	Backup                 *Backup     `json:"backup,omitempty"`
 }
 
 func (o Database) String() string {
@@ -177,6 +180,7 @@ type UpdateDatabase struct {
 	Password                            *string                      `json:"password,omitempty"`
 	Alerts                              []*UpdateAlert               `json:"alerts,omitempty"`
 	EnableTls                           *bool                        `json:"enableTls,omitempty"`
+	RemoteBackup                        *DatabaseBackupConfig        `json:"remoteBackup,omitempty"`
 }
 
 func (o UpdateDatabase) String() string {
@@ -260,6 +264,18 @@ const (
 	StatusProxyPolicyChangeDraft = "proxy-policy-change-draft"
 	// Error value of the `Status` field in `Database`
 	StatusError = "error"
+	// BackupIntervalEvery24Hours is the schedule to back up once a day
+	BackupIntervalEvery24Hours = "every-24-hours"
+	// BackupIntervalEvery12Hours is the schedule to back up twice a day
+	BackupIntervalEvery12Hours = "every-12-hours"
+	// BackupIntervalEvery6Hours is the schedule to back up four times a day
+	BackupIntervalEvery6Hours = "every-6-hours"
+	// BackupIntervalEvery4Hours is the schedule to back up six times a day
+	BackupIntervalEvery4Hours = "every-4-hours"
+	// BackupIntervalEvery2Hours is the schedule to back up twelve times a day
+	BackupIntervalEvery2Hours = "every-2-hours"
+	// BackupIntervalEvery1Hours is the schedule to back up every hour
+	BackupIntervalEvery1Hours = "every-1-hours"
 )
 
 func MemoryStorageValues() []string {
@@ -319,5 +335,25 @@ func AlertNameValues() []string {
 		"latency",
 		"syncsource-error",
 		"syncsource-lag",
+	}
+}
+
+func BackupStorageTypes() []string {
+	return []string{
+		"ftp",
+		"aws-s3",
+		"azure-blob-storage",
+		"google-blob-storage",
+	}
+}
+
+func BackupIntervals() []string {
+	return []string{
+		BackupIntervalEvery24Hours,
+		BackupIntervalEvery12Hours,
+		BackupIntervalEvery6Hours,
+		BackupIntervalEvery4Hours,
+		BackupIntervalEvery2Hours,
+		BackupIntervalEvery1Hours,
 	}
 }

--- a/service/databases/model_active_active.go
+++ b/service/databases/model_active_active.go
@@ -48,6 +48,7 @@ func (o CrdbDatabase) String() string {
 
 type Backup struct {
 	Enabled     *bool   `json:"enableRemoteBackup,omitempty"`
+	TimeUTC     *string `json:"timeUTC,omitempty"`
 	Interval    *string `json:"interval,omitempty"`
 	Destination *string `json:"destination,omitempty"`
 }
@@ -69,6 +70,7 @@ type CreateActiveActiveDatabase struct {
 	GlobalPassword                      *string            `json:"password,omitempty"`
 	GlobalAlerts                        []*CreateAlert     `json:"alerts,omitempty"`
 	LocalThroughputMeasurement          []*LocalThroughput `json:"localThroughputMeasurement,omitempty"`
+	PortNumber                          *int               `json:"port,omitempty"`
 }
 
 func (o CreateActiveActiveDatabase) String() string {

--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -174,13 +174,14 @@ func (o UpdateCIDRAllowlist) String() string {
 }
 
 type CreateVPCPeering struct {
-	Region         *string `json:"region,omitempty"`
-	AWSAccountID   *string `json:"awsAccountId,omitempty"`
-	VPCId          *string `json:"vpcId,omitempty"`
-	VPCCidr        *string `json:"vpcCidr,omitempty"`
-	Provider       *string `json:"provider,omitempty"`
-	VPCProjectUID  *string `json:"vpcProjectUid,omitempty"`
-	VPCNetworkName *string `json:"vpcNetworkName,omitempty"`
+	Region         *string   `json:"region,omitempty"`
+	AWSAccountID   *string   `json:"awsAccountId,omitempty"`
+	VPCId          *string   `json:"vpcId,omitempty"`
+	VPCCidr        *string   `json:"vpcCidr,omitempty"`
+	VPCCidrs       []*string `json:"vpcCidrs,omitempty"`
+	Provider       *string   `json:"provider,omitempty"`
+	VPCProjectUID  *string   `json:"vpcProjectUid,omitempty"`
+	VPCNetworkName *string   `json:"vpcNetworkName,omitempty"`
 }
 
 func (o CreateVPCPeering) String() string {
@@ -188,14 +189,15 @@ func (o CreateVPCPeering) String() string {
 }
 
 type CreateActiveActiveVPCPeering struct {
-	SourceRegion      *string `json:"sourceRegion,omitempty"`
-	DestinationRegion *string `json:"destinationRegion,omitempty"`
-	AWSAccountID      *string `json:"awsAccountId,omitempty"`
-	VPCId             *string `json:"vpcId,omitempty"`
-	VPCCidr           *string `json:"vpcCidr,omitempty"`
-	Provider          *string `json:"provider,omitempty"`
-	VPCProjectUID     *string `json:"vpcProjectUid,omitempty"`
-	VPCNetworkName    *string `json:"vpcNetworkName,omitempty"`
+	SourceRegion      *string   `json:"sourceRegion,omitempty"`
+	DestinationRegion *string   `json:"destinationRegion,omitempty"`
+	AWSAccountID      *string   `json:"awsAccountId,omitempty"`
+	VPCId             *string   `json:"vpcId,omitempty"`
+	VPCCidr           *string   `json:"vpcCidr,omitempty"`
+	VPCCidrs          []*string `json:"vpcCidrs,omitempty"`
+	Provider          *string   `json:"provider,omitempty"`
+	VPCProjectUID     *string   `json:"vpcProjectUid,omitempty"`
+	VPCNetworkName    *string   `json:"vpcNetworkName,omitempty"`
 }
 
 func (o CreateActiveActiveVPCPeering) String() string {
@@ -213,6 +215,7 @@ type VPCPeering struct {
 	AWSPeeringID     *string `json:"awsPeeringUid,omitempty"`
 	VPCId            *string `json:"vpcUid,omitempty"`
 	VPCCidr          *string `json:"vpcCidr,omitempty"`
+	VPCCidrs         []*CIDR `json:"vpcCidrs,omitempty"`
 	GCPProjectUID    *string `json:"projectUid,omitempty"`
 	NetworkName      *string `json:"networkName,omitempty"`
 	RedisProjectUID  *string `json:"redisProjectUid,omitempty"`
@@ -245,6 +248,7 @@ type ActiveActiveVPCPeering struct {
 	AWSPeeringID      *string `json:"awsPeeringUid,omitempty"`
 	VPCId             *string `json:"vpcUid,omitempty"`
 	VPCCidr           *string `json:"vpcCidr,omitempty"`
+	VPCCidrs          []*CIDR `json:"vpcCidrs,omitempty"`
 	GCPProjectUID     *string `json:"vpcProjectUid,omitempty"`
 	NetworkName       *string `json:"vpcNetworkName,omitempty"`
 	RedisProjectUID   *string `json:"redisProjectUid,omitempty"`
@@ -255,6 +259,15 @@ type ActiveActiveVPCPeering struct {
 }
 
 func (o ActiveActiveVPCPeering) String() string {
+	return internal.ToString(o)
+}
+
+type CIDR struct {
+	VPCCidr *string `json:"vpcCidr,omitempty"`
+	Status  *string `json:"active,omitempty"`
+}
+
+func (o CIDR) String() string {
 	return internal.ToString(o)
 }
 


### PR DESCRIPTION
Add support for setting the port number for all databases and backup for databases that aren't active/active. Also support setting multiple CIDR ranges when peering databases.