### PR TITLE
Fixing a bug with the query parameter in AA database latest-backup lookups

### DIFF
--- a/latest_backups_test.go
+++ b/latest_backups_test.go
@@ -186,9 +186,10 @@ func TestGetAALatestBackup(t *testing.T) {
 		testServer(
 			"key",
 			"secret",
-			getRequest(
+			getRequestWithQuery(
 				t,
-				"/subscriptions/12/databases/34/backup?regionName=eu-west-2",
+				"/subscriptions/12/databases/34/backup",
+				map[string][]string{"regionName": {"eu-west-2"}},
 				`{
 				  "taskId": "ce2cbfea-9b15-4250-a516-f014161a8dd3",
 				  "commandType": "databaseBackupStatusRequest",

--- a/service/latest_backups/service.go
+++ b/service/latest_backups/service.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/RedisLabs/rediscloud-go-api/internal"
 )
 
 type HttpClient interface {
 	Get(ctx context.Context, name, path string, responseBody interface{}) error
+	GetWithQuery(ctx context.Context, name, path string, query url.Values, responseBody interface{}) error
 }
 
 type TaskWaiter interface {
@@ -52,12 +54,37 @@ func (a *API) GetFixed(ctx context.Context, subscription int, database int) (*La
 
 func (a *API) GetActiveActive(ctx context.Context, subscription int, database int, region string) (*LatestBackupStatus, error) {
 	message := fmt.Sprintf("get latest backup information for database %d in subscription %d and region %s", subscription, database, region)
-	address := fmt.Sprintf("/subscriptions/%d/databases/%d/backup?regionName=%s", subscription, database, region)
-	task, err := a.get(ctx, message, address)
-	if err != nil {
-		return nil, wrap404ErrorActiveActive(subscription, database, region, err)
+	address := fmt.Sprintf("/subscriptions/%d/databases/%d/backup", subscription, database)
+
+	q := map[string][]string{
+		"regionName": {region},
 	}
-	return task, nil
+
+	var task internal.TaskResponse
+	err := a.client.GetWithQuery(ctx, message, address, q, &task)
+	if err != nil {
+		return nil, err
+	}
+
+	a.logger.Printf("Waiting for backup status request %d to complete", task.ID)
+
+	err = a.taskWaiter.Wait(ctx, *task.ID)
+
+	a.logger.Printf("Backup status request %d completed, possibly with error", task.ID, err)
+
+	var backupStatusTask *LatestBackupStatus
+	err = a.client.Get(ctx,
+		fmt.Sprintf("retrieve completed backup status task %d", task.ID),
+		"/tasks/"+*task.ID,
+		&backupStatusTask,
+	)
+
+	if err != nil {
+		return nil, wrap404ErrorActiveActive(subscription, database, region,
+			fmt.Errorf("failed to retrieve completed backup status %d: %w", task.ID, err))
+	}
+
+	return backupStatusTask, nil
 }
 
 func (a *API) get(ctx context.Context, message string, address string) (*LatestBackupStatus, error) {


### PR DESCRIPTION
The ? for query params was being encoded