### PR TITLE
feat: add support for marketplace payments into api

### DIFF
--- a/service/fixed/subscriptions/model.go
+++ b/service/fixed/subscriptions/model.go
@@ -12,6 +12,7 @@ type FixedSubscription struct {
 	Name            *string    `json:"name,omitempty"`
 	Status          *string    `json:"status,omitempty"` // Omit for Create and Update
 	PlanId          *int       `json:"planId,omitempty"`
+	PaymentMethod   *string    `json:"paymentMethod,omitempty"`
 	PaymentMethodID *int       `json:"paymentMethodId,omitempty"`
 	CreationDate    *time.Time `json:"creationDate,omitempty"` // Omit for Create and Update
 }


### PR DESCRIPTION
A very simple additional field added into the API. Added an additional test to exercise the potential use of this field.