### PR TITLE
Minor API fixes for AA regions

### DIFF
--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -278,16 +278,16 @@ type listSubscriptionResponse struct {
 	Subscriptions []*Subscription `json:"subscriptions"`
 }
 
-type ListSubscriptionRegionsResponse struct {
+type ListAASubscriptionRegionsResponse struct {
 	SubscriptionId *int                  `json:"subscriptionId,omitempty"`
 	Regions        []*ActiveActiveRegion `json:"regions"`
 }
 
 // have to redeclare these here (copied from regions model) to avoid an import cycle
 type ActiveActiveRegion struct {
-	RegionId       *int                   `json:"regionId,omitempty"`
+	//RegionId       *int `json:"regionId,omitempty"` // not populated by the API
 	Region         *string                `json:"region,omitempty"`
-	DeploymentCIDR *string                `json:"deploymentCIDR,omitempty"`
+	DeploymentCIDR *string                `json:"deploymentCidr,omitempty"`
 	VpcId          *string                `json:"vpcId,omitempty"`
 	Databases      []ActiveActiveDatabase `json:"databases,omitempty"`
 }

--- a/service/subscriptions/service.go
+++ b/service/subscriptions/service.go
@@ -239,7 +239,7 @@ func (a *API) DeleteActiveActiveVPCPeering(ctx context.Context, subscription int
 }
 
 func (a *API) ListActiveActiveRegions(ctx context.Context, subscription int) ([]*ActiveActiveRegion, error) {
-	var response ListSubscriptionRegionsResponse
+	var response ListAASubscriptionRegionsResponse
 	err := a.client.Get(ctx, "list regions", fmt.Sprintf("/subscriptions/%d/regions", subscription), &response)
 
 	if err != nil {

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -800,7 +800,6 @@ func TestSubscription_ListActiveActiveRegions(t *testing.T) {
 	  "subscriptionId": 1986,
 	  "regions": [
 		{
-		  "regionId": 12,
 		  "region": "us-east-1",
 		  "deploymentCidr": "192.169.0.0/24",
 		  "vpcId": "vpc-0e828cd5c0c580389",
@@ -817,7 +816,6 @@ func TestSubscription_ListActiveActiveRegions(t *testing.T) {
 		  "links": []
 		},
 		{
-		  "regionId": 19,
 		  "region": "us-east-2",
 		  "deploymentCidr": "11.0.1.0/24",
 		  "vpcId": "vpc-0aecab539b31057a5",
@@ -867,7 +865,6 @@ func listRegionsExpected() []*subscriptions.ActiveActiveRegion {
 
 	// Initialize regions
 	region1Struct := &subscriptions.ActiveActiveRegion{
-		RegionId:       redis.Int(12),
 		Region:         redis.String("us-east-1"),
 		DeploymentCIDR: redis.String("192.169.0.0/24"),
 		VpcId:          redis.String("vpc-0e828cd5c0c580389"),
@@ -875,7 +872,6 @@ func listRegionsExpected() []*subscriptions.ActiveActiveRegion {
 	}
 
 	region2Struct := &subscriptions.ActiveActiveRegion{
-		RegionId:       redis.Int(19),
 		Region:         redis.String("us-east-2"),
 		DeploymentCIDR: redis.String("11.0.1.0/24"),
 		VpcId:          redis.String("vpc-0aecab539b31057a5"),


### PR DESCRIPTION
- fix: deployment cidr named correctly now in JSON response
- fix: commenting out regionID as present in swagger but not populated by the API
- chore: renamed some variables for clarity