### PR TITLE
Customer managed encryption keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 * Adding an API call and endpoint for updating customer-managed encryption keys (CMKs) to an existing subscription.
+* Adding a new status to support the `encryption_key_pending` status of a subscription.
 
 ## 0.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
+## 0.31.0
+
+### Added
+
+* Adding an API call and endpoint for updating customer-managed encryption keys (CMKs) to an existing subscription.
+
 ## 0.30.0
 
 ### Added
 
-* Adding in support for `persistentStorageEncryptionType`, to support CMEK, across pro and active active subscription creation
+* Adding in support for `persistentStorageEncryptionType`, to support customer-managed encryption keys (CMKs) across pro and active-active subscription creation
 
 ## 0.29.0
 

--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -312,6 +312,8 @@ const (
 	SubscriptionStatusActive = "active"
 	// SubscriptionStatusPending is the pending value of the `Status` field in `Subscription`
 	SubscriptionStatusPending = "pending"
+	// SubscriptionStatusEncryptionKeyPending is the encryption key pending value of the `Status` field in `Subscription`
+	SubscriptionStatusEncryptionKeyPending = "encryption_key_pending"
 	// SubscriptionStatusError is the error value of the `Status` field in `Subscription`
 	SubscriptionStatusError = "error"
 	// SubscriptionStatusDeleting is the deleting value of the `Status` field in `Subscription`

--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -124,16 +124,23 @@ func (o UpdateSubscriptionCMKs) String() string {
 }
 
 type Subscription struct {
-	ID                *int           `json:"id,omitempty"`
-	Name              *string        `json:"name,omitempty"`
-	Status            *string        `json:"status,omitempty"`
-	DeploymentType    *string        `json:"deploymentType,omitempty"`
-	PaymentMethod     *string        `json:"paymentMethodType,omitempty"`
-	PaymentMethodID   *int           `json:"paymentMethodId,omitempty"`
-	MemoryStorage     *string        `json:"memoryStorage,omitempty"`
-	StorageEncryption *bool          `json:"storageEncryption,omitempty"`
-	NumberOfDatabases *int           `json:"numberOfDatabases,omitempty"`
-	CloudDetails      []*CloudDetail `json:"cloudDetails,omitempty"`
+	ID                              *int                             `json:"id,omitempty"`
+	Name                            *string                          `json:"name,omitempty"`
+	Status                          *string                          `json:"status,omitempty"`
+	DeploymentType                  *string                          `json:"deploymentType,omitempty"`
+	PaymentMethod                   *string                          `json:"paymentMethodType,omitempty"`
+	PaymentMethodID                 *int                             `json:"paymentMethodId,omitempty"`
+	MemoryStorage                   *string                          `json:"memoryStorage,omitempty"`
+	StorageEncryption               *bool                            `json:"storageEncryption,omitempty"`
+	NumberOfDatabases               *int                             `json:"numberOfDatabases,omitempty"`
+	CloudDetails                    []*CloudDetail                   `json:"cloudDetails,omitempty"`
+	CustomerManagedKeyAccessDetails *CustomerManagedKeyAccessDetails `json:"customerManagedKeyAccessDetails,omitempty"`
+}
+
+type CustomerManagedKeyAccessDetails struct {
+	RedisServiceAccount     *string   `json:"redisServiceAccount,omitempty"`
+	GooglePredefinedRoles   []*string `json:"googlePredefinedRoles,omitempty"`
+	GoogleCustomPermissions []*string `json:"googleCustomPermissions,omitempty"`
 }
 
 func (o Subscription) String() string {

--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -109,6 +109,20 @@ func (o UpdateSubscription) String() string {
 	return internal.ToString(o)
 }
 
+type UpdateSubscriptionCMKs struct {
+	DeletionGracePeriod *string               `json:"deletionGracePeriod,omitempty"`
+	CustomerManagedKeys *[]CustomerManagedKey `json:"customerManagedKeys,omitempty"`
+}
+
+type CustomerManagedKey struct {
+	ResourceName *string `json:"resourceName,omitempty"`
+	Region       *string `json:"region,omitempty"`
+}
+
+func (o UpdateSubscriptionCMKs) String() string {
+	return internal.ToString(o)
+}
+
 type Subscription struct {
 	ID                *int           `json:"id,omitempty"`
 	Name              *string        `json:"name,omitempty"`

--- a/service/subscriptions/service.go
+++ b/service/subscriptions/service.go
@@ -93,6 +93,24 @@ func (a *API) Update(ctx context.Context, id int, subscription UpdateSubscriptio
 	return nil
 }
 
+// Update will make changes to an existing subscription's CMKs.
+func (a *API) UpdateCMKs(ctx context.Context, id int, subscriptionCMKs UpdateSubscriptionCMKs) error {
+	var task internal.TaskResponse
+	err := a.client.Put(ctx, fmt.Sprintf("update subscription %d", id), fmt.Sprintf("/subscriptions/%d", id), subscriptionCMKs, &task)
+	if err != nil {
+		return wrap404Error(id, err)
+	}
+
+	a.logger.Printf("Waiting for task %s to finish updating the subscription", task)
+
+	err = a.taskWaiter.Wait(ctx, *task.ID)
+	if err != nil {
+		return fmt.Errorf("failed when updating subscription %d: %w", id, err)
+	}
+
+	return nil
+}
+
 // Delete will destroy an existing subscription. All existing databases within the subscription should already be
 // deleted, otherwise this function will fail.
 func (a *API) Delete(ctx context.Context, id int) error {

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -592,6 +592,66 @@ func TestSubscription_Update(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSubscription_Update_CMKs(t *testing.T) {
+
+	const request = `
+	{
+	  "deletionGracePeriod": "test",
+	  "customerManagedKeys": [
+		{
+			"resourceName": "test_cmk",
+			"region": "us-east-1"
+		}
+		]
+	}
+`
+
+	const body = `{
+		  "taskId": "task",
+		  "commandType": "subscriptionUpdateRequest",
+		  "status": "received",
+		  "description": "Task request received and is being queued for processing.",
+		  "timestamp": "2020-11-02T09:05:34.3Z",
+		  "_links": {
+			"task": {
+			  "href": "https://example.org",
+			  "title": "getTaskStatusUpdates",
+			  "type": "GET"
+			}
+		  }
+		}`
+
+	s := httptest.NewServer(testServer("key", "secret", putRequest(t, "/subscriptions/1234", request, body), getRequest(t, "/tasks/task", `{
+  "taskId": "e02b40d6-1395-4861-a3b9-ecf829d835fd",
+  "commandType": "subscriptionUpdateRequest",
+  "status": "processing-completed",
+  "timestamp": "2020-10-28T09:58:16.798Z",
+  "response": {
+  },
+  "_links": {
+    "self": {
+      "href": "https://example.com",
+      "type": "GET"
+    }
+  }
+}`)))
+	defer s.Close()
+
+	subject, err := clientFromTestServer(s, "key", "secret")
+	require.NoError(t, err)
+
+	err = subject.Subscription.UpdateCMKs(context.TODO(), 1234, subscriptions.UpdateSubscriptionCMKs{
+		DeletionGracePeriod: redis.String("test"),
+		CustomerManagedKeys: &[]subscriptions.CustomerManagedKey{
+			{
+				ResourceName: redis.String("test_cmk"),
+				Region:       redis.String("us-east-1"),
+			},
+		},
+	})
+
+}
+
 func TestSubscription_Delete(t *testing.T) {
 	s := httptest.NewServer(testServer("apiKey", "secret", deleteRequest(t, "/subscriptions/12356", `{
   "taskId": "task",


### PR DESCRIPTION
* Adding an API call and endpoint for updating customer-managed encryption keys (CMKs) to an existing subscription.
* Adding a new status to support the `encryption_key_pending` status of a subscription.