### PR TITLE
feat: aws cmk support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
+## 0.50.0 (7th May 2026)
+* Added `AwsRoleArn` and `AwsRequiredPermissions` fields to `CustomerManagedKeyAccessDetails`, exposing the IAM role and KMS permissions returned for AWS CMK subscriptions.
+
 ## 0.49.0 (29th April 2026)
 * Added `Name` field to `UpdateActiveActiveDatabase`, allowing for Active-Active database name change.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.50.0 (7th May 2026)
-* Added `AwsRoleArn` and `AwsRequiredPermissions` fields to `CustomerManagedKeyAccessDetails`, exposing the IAM role and KMS permissions returned for AWS CMK subscriptions.
+* Added `AwsRoleArn` field to `CustomerManagedKeyAccessDetails`, mapped to the `redisIamRole` API response, exposing the IAM role for AWS CMK subscriptions.
 
 ## 0.49.0 (29th April 2026)
 * Added `Name` field to `UpdateActiveActiveDatabase`, allowing for Active-Active database name change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
-## 0.50.0 (7th May 2026)
-* Added `AwsRoleArn` field to `CustomerManagedKeyAccessDetails`, mapped to the `redisIamRole` API response, exposing the IAM role for AWS CMK subscriptions.
+## 0.50.0 (12th May 2026)
+* Added `AwsRoleArn` field to `CustomerManagedKeyAccessDetails`.
+* Bumped Go toolchain to `go1.25.10`.
 
 ## 0.49.0 (29th April 2026)
 * Added `Name` field to `UpdateActiveActiveDatabase`, allowing for Active-Active database name change.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/RedisLabs/rediscloud-go-api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/avast/retry-go/v4 v4.7.0

--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -166,8 +166,7 @@ type CustomerManagedKeyAccessDetails struct {
 	RedisServiceAccount     *string   `json:"redisServiceAccount,omitempty"`
 	GooglePredefinedRoles   []*string `json:"googlePredefinedRoles,omitempty"`
 	GoogleCustomPermissions []*string `json:"googleCustomPermissions,omitempty"`
-	AwsRoleArn              *string   `json:"awsRoleArn,omitempty"`
-	AwsRequiredPermissions  []*string `json:"awsRequiredPermissions,omitempty"`
+	AwsRoleArn              *string   `json:"redisIamRole,omitempty"`
 }
 
 func (o Subscription) String() string {

--- a/service/subscriptions/model.go
+++ b/service/subscriptions/model.go
@@ -166,6 +166,8 @@ type CustomerManagedKeyAccessDetails struct {
 	RedisServiceAccount     *string   `json:"redisServiceAccount,omitempty"`
 	GooglePredefinedRoles   []*string `json:"googlePredefinedRoles,omitempty"`
 	GoogleCustomPermissions []*string `json:"googleCustomPermissions,omitempty"`
+	AwsRoleArn              *string   `json:"awsRoleArn,omitempty"`
+	AwsRequiredPermissions  []*string `json:"awsRequiredPermissions,omitempty"`
 }
 
 func (o Subscription) String() string {

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -982,6 +982,42 @@ func TestSubscription_Get_WithResourceTags(t *testing.T) {
 	}, actual.CloudDetails[0].ResourceTags)
 }
 
+// TestSubscription_Get_WithCMKAccessDetails locks down the JSON tag mapping for
+// every field on CustomerManagedKeyAccessDetails — in particular, that
+// `redisIamRole` populates AwsRoleArn.
+func TestSubscription_Get_WithCMKAccessDetails(t *testing.T) {
+	s := httptest.NewServer(testServer("apiKey", "secret", getRequest(t, "/subscriptions/98768", `{
+  "id": 4,
+  "name": "Get-cmk-access-details",
+  "status": "active",
+  "paymentMethodType": "credit-card",
+  "paymentMethodId": 2,
+  "memoryStorage": "ram",
+  "storageEncryption": false,
+  "persistentStorageEncryptionType": "customer-managed-key",
+  "numberOfDatabases": 1,
+  "customerManagedKeyAccessDetails": {
+    "redisServiceAccount": "redis-cmk@redislabs.iam.gserviceaccount.com",
+    "googlePredefinedRoles": ["roles/cloudkms.cryptoKeyEncrypterDecrypter"],
+    "googleCustomPermissions": ["cloudkms.cryptoKeyVersions.useToEncrypt"],
+    "redisIamRole": "arn:aws:iam::123456789012:role/redis-cmk"
+  }
+}`)))
+
+	subject, err := clientFromTestServer(s, "apiKey", "secret")
+	require.NoError(t, err)
+
+	actual, err := subject.Subscription.Get(context.TODO(), 98768)
+	require.NoError(t, err)
+
+	assert.Equal(t, &subscriptions.CustomerManagedKeyAccessDetails{
+		RedisServiceAccount:     redis.String("redis-cmk@redislabs.iam.gserviceaccount.com"),
+		GooglePredefinedRoles:   redis.StringSlice("roles/cloudkms.cryptoKeyEncrypterDecrypter"),
+		GoogleCustomPermissions: redis.StringSlice("cloudkms.cryptoKeyVersions.useToEncrypt"),
+		AwsRoleArn:              redis.String("arn:aws:iam::123456789012:role/redis-cmk"),
+	}, actual.CustomerManagedKeyAccessDetails)
+}
+
 func TestSubscription_Get_wraps404Error(t *testing.T) {
 	s := httptest.NewServer(testServer("apiKey", "secret", getRequestWithStatus(t, "/subscriptions/123", 404, "")))
 


### PR DESCRIPTION
## Added
- Added `AwsRoleArn` and `AwsRequiredPermissions` fields to `CustomerManagedKeyAccessDetails`, exposing the IAM role and KMS permissions returned for AWS CMK subscriptions.