### PR TITLE
feat: Align cloud account status values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
+## 0.51.0 (30th June 2026)
+
+### Added:
+* Added `StatusPending`, `StatusChangePending`, `StatusDeleteDraft`, `StatusDeleted` and `StatusActiveError` constants for the `Status` field in `CloudAccount`.
+
 ## 0.50.0 (12th May 2026)
 * Added `AwsRoleArn` field to `CustomerManagedKeyAccessDetails`.
 * Bumped Go toolchain to `go1.25.10`.

--- a/fixture_test.go
+++ b/fixture_test.go
@@ -99,10 +99,14 @@ func TestDatabaseFixtures(t *testing.T) {
 }
 
 func TestCloudAccountFixtures(t *testing.T) {
-	assert.Equal(t, "active", cloud_accounts.StatusActive)
 	assert.Equal(t, "draft", cloud_accounts.StatusDraft)
+	assert.Equal(t, "pending", cloud_accounts.StatusPending)
+	assert.Equal(t, "active", cloud_accounts.StatusActive)
 	assert.Equal(t, "change-draft", cloud_accounts.StatusChangeDraft)
-	assert.Equal(t, "error", cloud_accounts.StatusError)
+	assert.Equal(t, "change-pending", cloud_accounts.StatusChangePending)
+	assert.Equal(t, "delete-draft", cloud_accounts.StatusDeleteDraft)
+	assert.Equal(t, "deleted", cloud_accounts.StatusDeleted)
+	assert.Equal(t, "active-error", cloud_accounts.StatusActiveError)
 	assert.Equal(t, []string{"AWS", "GCP"}, cloud_accounts.ProviderValues())
 }
 

--- a/service/cloud_accounts/model.go
+++ b/service/cloud_accounts/model.go
@@ -58,14 +58,22 @@ func (o CloudAccount) String() string {
 }
 
 const (
-	// StatusActive is the active value of the `Status` field in `CloudAccount`
-	StatusActive = "active"
 	// StatusDraft is the draft value of the `Status` field in `CloudAccount`
 	StatusDraft = "draft"
+	// StatusPending is the pending value of the `Status` field in `CloudAccount`
+	StatusPending = "pending"
+	// StatusActive is the active value of the `Status` field in `CloudAccount`
+	StatusActive = "active"
 	// StatusChangeDraft is the change draft value of the `Status` field in `CloudAccount`
 	StatusChangeDraft = "change-draft"
-	// StatusError is the error value of the `Status` field in `CloudAccount`
-	StatusError = "error"
+	// StatusChangePending is the change pending value of the `Status` field in `CloudAccount`
+	StatusChangePending = "change-pending"
+	// StatusDeleteDraft is the delete draft value of the `Status` field in `CloudAccount`
+	StatusDeleteDraft = "delete-draft"
+	// StatusDeleted is the deleted value of the `Status` field in `CloudAccount`
+	StatusDeleted = "deleted"
+	// StatusActiveError is the active error value of the `Status` field in `CloudAccount`
+	StatusActiveError = "active-error"
 )
 
 func ProviderValues() []string {


### PR DESCRIPTION
Align the cloud account status values to the [current CAPI ones](https://github.com/redislabsdev/sm-cloud-api/blob/31588941e5387ad8edf3e1a77294b5cad6ac0dd9/sm-redislabs-api-data-model/src/main/java/com/redislabs/model/auto/CloudAccountItem.java#L510-L517)

Note: We are removing the `StatusError = "error"`, since it's not a valid value. It is also not yet used anywhere in the [Redis TF provider](https://github.com/RedisLabs/terraform-provider-rediscloud) project, so it's a safe (although breaking) change.