### PR TITLE
fix: Update go version to fix vulncheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/RedisLabs/rediscloud-go-api
 
 go 1.24.0
 
-toolchain go1.25.10
+toolchain go1.25.11
 
 require (
 	github.com/avast/retry-go/v4 v4.7.0


### PR DESCRIPTION
Fixes a [vulncheck error for go 1.25.10](https://github.com/RedisLabs/rediscloud-go-api/actions/runs/28433801609/job/84254685104?pr=264)