### PR TITLE
feat: Automate versioning via git tags

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,26 @@
+name: Tag Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - version.go
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-tags: true # so a duplicate tag makes `git tag` fail
+
+      - name: Tag the version from version.go
+        run: |
+          version="$(grep -oE 'Version = "[0-9]+\.[0-9]+\.[0-9]+"' version.go | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+          echo "Tagging v$version"
+          git tag "v$version"
+          git push origin "v$version"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
+## 0.52.0 (1st July 2026)
+
+### Changed:
+* Releases are now tagged automatically: on merge to `main`, a GitHub Actions workflow publishes a `vX.Y.Z` Git tag derived from the `Version` constant in `version.go`.
+
 ## 0.51.0 (30th June 2026)
 
 ### Added:

--- a/README.md
+++ b/README.md
@@ -41,3 +41,16 @@ func main() {
 	fmt.Printf("Created subscription: %d", id)
 }
 ```
+
+## Releasing
+
+Releases are published as Git tags of the form `vX.Y.Z`, so Go consumers pull a
+specific release with `go get github.com/RedisLabs/rediscloud-go-api@vX.Y.Z`.
+
+Tagging is automated on merge to `main`, using the [Tag Release workflow](.github/workflows/tag-release.yml). The `Version` constant in [`version.go`](version.go) is
+the single source of truth for the release number.
+
+To cut a release:
+1. Bump `Version` in [`version.go`](version.go) (e.g. `0.51.0` → `0.52.0`).
+2. Make sure there is a matching entry in [`CHANGELOG.md`](CHANGELOG.md).
+3. Open a PR and merge it into `main`.

--- a/user_agent.go
+++ b/user_agent.go
@@ -1,0 +1,23 @@
+package rediscloud_api
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+const (
+	// AccessKeyEnvVar is the environment variable that will be used for the access key by default.
+	AccessKeyEnvVar = "REDISCLOUD_ACCESS_KEY"
+
+	// SecretKeyEnvVar is the environment variable that will be used for the secret key by default.
+	SecretKeyEnvVar = "REDISCLOUD_SECRET_KEY"
+)
+
+var userAgent = buildUserAgent("rediscloud-go-api", Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+
+func buildUserAgent(name string, version string, info ...string) string {
+	product := fmt.Sprintf("%s/%s", name, version)
+	systemInfo := strings.Join(info, "; ")
+	return fmt.Sprintf("%s (%s)", product, systemInfo)
+}

--- a/version.go
+++ b/version.go
@@ -1,26 +1,4 @@
 package rediscloud_api
 
-import (
-	"fmt"
-	"runtime"
-	"strings"
-)
-
-const (
-	// Version is the release number of this SDK.
-	Version = "0.2.0"
-
-	// AccessKeyEnvVar is the environment variable that will be used for the access key by default.
-	AccessKeyEnvVar = "REDISCLOUD_ACCESS_KEY"
-
-	// SecretKeyEnvVar is the environment variable that will be used for the secret key by default.
-	SecretKeyEnvVar = "REDISCLOUD_SECRET_KEY"
-)
-
-var userAgent = buildUserAgent("rediscloud-go-api", Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
-
-func buildUserAgent(name string, version string, info ...string) string {
-	product := fmt.Sprintf("%s/%s", name, version)
-	systemInfo := strings.Join(info, "; ")
-	return fmt.Sprintf("%s (%s)", product, systemInfo)
-}
+// Version is the release number of this SDK.
+const Version = "0.52.0"


### PR DESCRIPTION
Automate release tagging, so it's no longer done by hand

- Add a `Tag Release` workflow
- Slim `version.go` to just the `Version` const
- Move the User-Agent code and the `AccessKeyEnvVar`/`SecretKeyEnvVar` constants into `user_agent.go`
- Bumps `Version` to `0.52.0` — the first release cut via this automation
- Update documentation