### PR TITLE
Simplify Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,5 @@ jobs:
       - name: Check for vulnerabilities
         run: nix develop --command govulncheck ./...
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-        with:
-          version: v2.12.2
-
       - name: Build and Test
         run: nix develop --command make

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,13 @@
-PACKAGE := github.com/RedisLabs/rediscloud-go-api
+.DEFAULT_GOAL := ci
+.PHONY: fmt lint test ci
 
-.DEFAULT_GOAL := all
-.PHONY := clean all fmt coverage
+fmt:
+	golangci-lint fmt
 
-go_files := $(shell find . -type f -name '*.go' -print)
+lint:
+	golangci-lint run
 
-clean:
-	# Removing all generated files...
-	@rm -rf bin/ || true
+test:
+	go test -v ./...
 
-bin/.vendor: go.mod go.sum
-	# Downloading modules...
-	@go mod download
-	@mkdir -p bin/
-	@touch bin/.vendor
-
-bin/.generate: $(go_files) bin/.vendor
-	@go generate ./...
-	@touch bin/.generate
-
-fmt: bin/.generate $(go_files)
-	# Formatting files...
-	@goimports -w $(go_files)
-
-bin/.vet: bin/.generate $(go_files)
-	go vet ./...
-	@touch bin/.vet
-
-bin/.fmtcheck: bin/.generate $(go_files)
-	# Checking format of Go files...
-	@GOIMPORTS=$$(goimports -l $(go_files)) && \
-	if [ "$$GOIMPORTS" != "" ]; then \
-		goimports -d $(go_files); \
-		exit 1; \
-	fi
-	@touch bin/.fmtcheck
-
-bin/.coverage.out: bin/.generate $(go_files)
-	@go test -cover -v -count=1 ./... -coverpkg=$(shell go list ${PACKAGE}/... | xargs | sed -e 's/ /,/g') -coverprofile bin/.coverage.tmp
-	@mv bin/.coverage.tmp bin/.coverage.out
-
-coverage: bin/.coverage.out
-	@go tool cover -html=bin/.coverage.out
-
-all: bin/.coverage.out bin/.fmtcheck
+ci: lint test


### PR DESCRIPTION
## Fixed
`.PHONY` was a variable assignment, not _PHONY_ declaration (`:=` vs `:`).
- Consistent `@` usage - we want verbose output in the CI, no need to silence it (can be simulated with `make -s`)

## Removed
- `GO_FILES` - `golangci-lint` takes care of everything
- `coverage` - we don't really track the coverage. If we decide to integrate it (or visualize it), we can bring it back.
- `vendor` goal - no vendored dependencies
- `generate` goal - no `go:generate` usage in the entire codebase
- `clean` goal - not needed after removal of the test coverage
- `vet` goal - already included in the `golangci-run` config
- `goimports` goal - already included in the `golangci-run` config
- `count=1` - for CI it doesn't matter, locally we can use the cache

## Renamed
- Rename `fmtcheck` goal to `lint`
- Rename `all` goal to `ci`